### PR TITLE
 Changes to work with our Parallel Cluster setup (squashed)

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -4,30 +4,20 @@
   }.map(&:name).grep(/^P./)
 -%>
 ---
-cluster: "pitzer"
+cluster: "*"
+cacheable: false
 form:
-  - account
   - bc_num_hours
-  - working_dir
+  - bc_num_slots
   - version
+  - custom_num_cores
 attributes:
-  account:
-    label: "Project"
-    widget: select
-    options:
-      <%- groups.each do |group| %>
-      - "<%= group %>"
-    <%- end %>
-  version:
-    widget: "select"
-    label: "Codeserver Version"
-    options:
-      - ["4.8", "4.8.3"]
-      - ["3.9", "3.9.3"]
-
-  working_dir:
-    label: "Working Directory"
-    data-filepicker: true
-    data-target-file-type: dirs  # Valid values are: files, dirs, or both
-    readonly: false
-    help: "Select your project directory; defaults to $HOME"
+  version: "4.12.0"
+  bc_num_slots: null
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1

--- a/info.md.erb
+++ b/info.md.erb
@@ -1,2 +1,1 @@
-Code Server launches inside of a [Singularity](https://sylabs.io/singularity/) container. **Note:** type `bash` to break out of the Singularity shell when using the integrated terminal in Code Server. 
-
+Code Server launches with spack module, so the shared spack installation will be active in the terminal within the VS Code interface.

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,9 +4,7 @@ category: Interactive Apps
 subcategory: Servers
 role: batch_connect
 description: |
-  This app will launch a [VS Code] server using [Code Server] on the [Pitzer
-  cluster].
+  This app will launch a [VS Code] server using [Code Server].
 
   [VS Code]: https://code.visualstudio.com/
   [Code Server]: https://coder.com/
-  [Pitzer cluster]: https://www.osc.edu/resources/technical_support/supercomputers/pitzer

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -3,5 +3,8 @@ batch_connect:
   template: "basic"
   conn_params:
     - code_server_version
+  set_host: "host=$(hostname | awk '{print $1}').<%= cluster%>.pcluster"
 script:
-  accounting_id: <%= account %>
+  native:
+    - "--nodes=1"
+    - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,17 +1,10 @@
 #!/usr/bin/bash -l
 <%
 
-# Set our working directory.
-working_dir = Pathname.new(context.working_dir)
+code_server_version = context.version
 
-code_server_version   = context.version
-
-# Ensure that code-server always starts up in either a user defined directory or the home directory.
-if ! working_dir.exist?
-    working_dir = Pathname.new(ENV['HOME'])
-elsif working_dir.file?
-    working_dir = working_dir.parent
-end
+# Ensure that code-server always starts up in the home directory.
+working_dir = Pathname.new(ENV['HOME'])
 %>
 
 CODE_SERVER_DATAROOT="$HOME/.local/share/code-server"
@@ -24,7 +17,16 @@ export PASSWORD="$password"
 echo "$(date): Running on compute node ${compute_node}:$port"
 
 # VSCode complains that system git is too old.
-module load project/ondemand git app_code_server/<%= code_server_version %>
+# module load project/ondemand git app_code_server/<%= code_server_version %>
+
+# Activate the shared spack environment
+. /shared/software/spack/share/spack/setup-env.sh
+echo "which spack:"
+which spack
+
+# Use spack to load code-server
+spack unload --all
+spack load code-server@<%= code_server_version %>
 
 CPP_FILE="<%= working_dir.to_s %>/.vscode/c_cpp_properties.json"
 
@@ -56,4 +58,5 @@ code-server \
     --ignore-last-opened \
     --user-data-dir="$CODE_SERVER_DATAROOT" \
     --log debug \
+    # --verbose \
     "<%= working_dir.to_s %>"

--- a/view.html.erb
+++ b/view.html.erb
@@ -23,11 +23,11 @@
 })();
 </script>
 
-<% if code_server_version == '4.8.3' %>
-<form id="<%= form_id %>" action="/rnode/<%= host %>/<%= port %>/login?to=" method="post" target="_blank">
-  <input type="hidden" name="password" value="<%= password %>">
+<% if code_server_version == '4.12.0' %>
+  <form id="<%= form_id %>" action="/rnode/<%= host %>/<%= port %>/login?to=" method="post" target="_blank">
+    <input type="hidden" name="password" value="<%= password %>">
 <% else %>
-<form id="<%= form_id %>" action="/rnode/<%= host %>/<%= port %>/" method="get" target="_blank">
+  <form id="<%= form_id %>" action="/rnode/<%= host %>/<%= port %>/" method="get" target="_blank">
 <% end %>
   <button class="btn btn-primary" type="submit">
     <i class="fa fa-cogs"></i> Connect to VS Code


### PR DESCRIPTION
This PR implements changes necessary to make this app work in our parallel cluster environment. It uses spack to load the code-server module, which the app expects to be installed to a shared location at /shared/software/spack in order to activate the spack environment. It runs on whatever clusters are available to a user, so we don't have to change the setup between dev and prod, and it allows users to select 1-4 CPUs to allocate to the session. Settings aren't cached between sessions, so just because you needed 4 cores for 12 hours once doesn't mean that's your new default.

I previously merged a branch with a messy history, this fixes that.