### PR TITLE
Fix wrong home directories

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,4 +1,10 @@
 #!/usr/bin/bash -l
+
+echo "original HOME=$HOME"
+echo "user=$(id -nu)"
+export HOME="/shared/home/$(id -nu)"
+echo "new HOME=$HOME"
+
 <%
 
 code_server_version = context.version
@@ -6,11 +12,6 @@ code_server_version = context.version
 # Ensure that code-server always starts up in the home directory.
 working_dir = Pathname.new(ENV['HOME'])
 %>
-
-echo "original HOME=$HOME"
-echo "user=$(id -nu)"
-export HOME="/shared/home/$(id -nu)"
-echo "new HOME=$HOME"
 
 CODE_SERVER_DATAROOT="$HOME/.local/share/code-server"
 mkdir -p "$CODE_SERVER_DATAROOT/extensions"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -7,6 +7,11 @@ code_server_version = context.version
 working_dir = Pathname.new(ENV['HOME'])
 %>
 
+echo "original HOME=$HOME"
+echo "user=$(id -nu)"
+export HOME="/shared/home/$(id -nu)"
+echo "new HOME=$HOME"
+
 CODE_SERVER_DATAROOT="$HOME/.local/share/code-server"
 mkdir -p "$CODE_SERVER_DATAROOT/extensions"
 

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -1,9 +1,15 @@
 #!/usr/bin/bash -l
 
+# Validate home directory and set it to what it should be
 echo "original HOME=$HOME"
 echo "user=$(id -nu)"
 export HOME="/shared/home/$(id -nu)"
 echo "new HOME=$HOME"
+
+# Validate shell and set it to what it should be
+echo "original SHELL=$SHELL"
+export SHELL="/bin/bash"
+echo "new SHELL=$SHELL"
 
 <%
 


### PR DESCRIPTION
Sometimes, for reasons that are currently unclear, a session will start with the `$HOME` and `$SHELL` environment variables unset. In looking at the output.log files and comparing between "good" sessions and "bad" sessions, I also see that `XDG_SESSION_ID` and `XDG_SESSION_ID` are unset in "bad" sessions, but it's not clear what the implications of those being missing are.

This results in a home directory being created at the wrong location, `/home/<netID>` on the head node rather than `/shared/home/<netID>` on the shared EFS, for those sessions. This can result in student work being split between two places, one of which could be destroyed by re-spinning the head node.

This PR adds some lines to the app to ensure that the `HOME` and `SHELL` environment variables get set, and logs their values to output.log so that problem sessions can be identified. This is a kind of kludgy fix to what seems like it might be a bigger and harder to diagnose problem, but it gets things working for the spring term.