### PR TITLE
add environment config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /tmp/
-/local/
 /code-server*/

--- a/local/cs2050-cpu.yml.erb
+++ b/local/cs2050-cpu.yml.erb
@@ -31,7 +31,7 @@ else
     # Cannot have other enabled groups if a course installation is in use
     # This is because the course installation uses the course shared folder,
     # which is not accessible to users outside of that course.
-    "144286" # COMPSCI 2050: High Performance Computing for Science and Engineering
+    # "144286" # COMPSCI 2050: High Performance Computing for Science and Engineering
   ]
 
   # Check if the groups that the user is in match any of the courses that should

--- a/local/cs2050-cpu.yml.erb
+++ b/local/cs2050-cpu.yml.erb
@@ -37,7 +37,7 @@ else
   # Check if the groups that the user is in match any of the courses that should
   # have access to this app.
 
-  if arrays_have_common_element(userGroups, enabledGroups)
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
     cluster="*"
   else
     cluster="disable_this_app"

--- a/local/cs2050-cpu.yml.erb
+++ b/local/cs2050-cpu.yml.erb
@@ -1,0 +1,67 @@
+# Custom setup for COMPSCI 2050. Allows users to set a number of CPU cores up to
+# the total number of cores available on our general purpose compute nodes,
+# currently 36. App is named to indicate it is a CPU app, since CS 2050 has
+# requested the same setup in the GPU queue.
+
+# Included in initial template
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
+# Added to control group access to apps
+<%-
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+  enabledGroups = [
+    # Cannot have other enabled groups if a course installation is in use
+    # This is because the course installation uses the course shared folder,
+    # which is not accessible to users outside of that course.
+    "144286" # COMPSCI 2050: High Performance Computing for Science and Engineering
+  ]
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+title: Code Server (COMPSCI 2050 - CPU)
+cluster: "<%= cluster %>"
+cacheable: false
+form:
+  - bc_num_hours
+  - bc_num_slots
+  - bc_queue
+  - version
+  - custom_num_cores
+attributes:
+  version: "4.12.0"
+  bc_num_slots: null
+  bc_queue: general
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 36
+    step: 1

--- a/local/cs2050-gpu.yml.erb
+++ b/local/cs2050-gpu.yml.erb
@@ -31,7 +31,7 @@ else
     # Cannot have other enabled groups if a course installation is in use
     # This is because the course installation uses the course shared folder,
     # which is not accessible to users outside of that course.
-    "144286" # COMPSCI 2050: High Performance Computing for Science and Engineering
+    # "144286" # COMPSCI 2050: High Performance Computing for Science and Engineering
   ]
 
   # Check if the groups that the user is in match any of the courses that should

--- a/local/cs2050-gpu.yml.erb
+++ b/local/cs2050-gpu.yml.erb
@@ -37,7 +37,7 @@ else
   # Check if the groups that the user is in match any of the courses that should
   # have access to this app.
 
-  if arrays_have_common_element(userGroups, enabledGroups)
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
     cluster="*"
   else
     cluster="disable_this_app"

--- a/local/cs2050-gpu.yml.erb
+++ b/local/cs2050-gpu.yml.erb
@@ -1,0 +1,61 @@
+# Custom setup for COMPSCI 2050. Allows users to set a number of CPU cores up to
+# the total number of cores available on our general purpose compute nodes,
+# currently 36. App is named to indicate it is a CPU app, since CS 2050 has
+# requested the same setup in the GPU queue.
+
+# Included in initial template
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
+# Added to control group access to apps
+<%-
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+  enabledGroups = [
+    # Cannot have other enabled groups if a course installation is in use
+    # This is because the course installation uses the course shared folder,
+    # which is not accessible to users outside of that course.
+    "144286" # COMPSCI 2050: High Performance Computing for Science and Engineering
+  ]
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+title: Code Server (COMPSCI 2050 - GPU)
+cluster: "<%= cluster %>"
+cacheable: false
+form:
+  - bc_num_hours
+  - bc_num_slots
+  - bc_queue
+  - version
+  - custom_num_cores
+attributes:
+  version: "4.12.0"
+  bc_num_slots: null
+  bc_queue: "gpu"
+  custom_num_cores: 8

--- a/local/cs2540.yml.erb
+++ b/local/cs2540.yml.erb
@@ -36,7 +36,7 @@ else
   # Check if the groups that the user is in match any of the courses that should
   # have access to this app.
 
-  if arrays_have_common_element(userGroups, enabledGroups)
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
     cluster="*"
   else
     cluster="disable_this_app"

--- a/local/cs2540.yml.erb
+++ b/local/cs2540.yml.erb
@@ -1,0 +1,64 @@
+# Custom setup for COMPSCI 2540. Allows users to set a number of CPU cores up to
+# the total number of cores available on our general purpose compute nodes,
+# currently 36.
+
+# Included in initial template
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
+# Added to control group access to apps
+<%-
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+  enabledGroups = [
+    # Cannot have other enabled groups if a course installation is in use
+    # This is because the course installation uses the course shared folder,
+    # which is not accessible to users outside of that course.
+    "144301" # COMPSCI 2540: Formal Methods for Computer Security
+  ]
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+title: Code Server (COMPSCI 2540)
+cluster: "<%= cluster %>"
+cacheable: false
+form:
+  - bc_num_hours
+  - bc_num_slots
+  - version
+  - custom_num_cores
+attributes:
+  version: "4.12.0"
+  bc_num_slots: null
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 36
+    step: 1

--- a/local/default.yml.erb
+++ b/local/default.yml.erb
@@ -4,6 +4,7 @@
   }.map(&:name).grep(/^P./)
 -%>
 ---
+title: Code Server
 cluster: "*"
 cacheable: false
 form:


### PR DESCRIPTION
# Overview

This PR adds new sub-app configurations for our instance of the Code Server app, tailored for use in particular courses. In this case, that means configurations for CS 2050 and CS 2540, which have asked for interactive VS Code apps with access to more resources, as students prefer working interactively in this environment.

This is also a departure from the previous setup, where there was only one version of the app for students to use. In order to preserve the current version of the app for current users in other classes, a "default" version of the config was added to the `local` folder as well.

# Changes

Added config files to new `local` dir:
- `cs2050-cpu.yml.erb` - inactive
- `cs2050-gpu.yml.erb` - inactive
- `cs2540.yml.erb`
- `default.yml.erb`

These files shouldn't be ignored in our setup, so the line in the `.gitignore` ignoring the `local` directory was removed.

The configs marked "inactive" for CS 2050 have the allowed Canvas ID commented out. This makes them ready to test by admins, but not yet available to students in the course. I haven't heard confirmation from the instructor in CS 2050 that these should be deployed just yet, but the CS 2540 changes are ready to go.