### PR TITLE
Ensure compute node name is included in log output

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -26,7 +26,7 @@ mkdir -p "$CODE_SERVER_DATAROOT/extensions"
 export PASSWORD="$password"
 
 # Print compute node.
-echo "TIMING: $(date -Iseconds) - Running on compute node ${compute_node}:$port"
+echo "TIMING: $(date -Iseconds) - Running on compute node ${SLURMD_NODENAME}:$port"
 
 # VSCode complains that system git is too old.
 # module load project/ondemand git app_code_server/<%= code_server_version %>


### PR DESCRIPTION
# Overview

This PR modifies the script to ensure the compute node name is included (currently just the port is displayed in the log output).

# Changes

- Updated `templates/script.sh.erb`.

# Notes

# References

- https://slurm.schedmd.com/sbatch.html#OPT_SLURMD_NODENAME